### PR TITLE
Add bundle_path parameter

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -30,13 +30,17 @@ commands:
         type: integer
         default: 3
         description: "Parameter for `bundle install --retry`"
+      bundle_path:
+        type: string
+        default: vendor/bundle
+        description: "Parameter for `bundle install --path`"
     steps:
       - restore_cache:
           keys: 
             - bundle-cache-{{ checksum "Gemfile.lock" }}
             - bundle-cache
-      - run: bundle install --jobs=<< parameters.jobs >> --retry=<< parameters.retry >> --path vendor/bundle
+      - run: bundle install --jobs=<< parameters.jobs >> --retry=<< parameters.retry >> --path << parameters.bundle_path >>
       - save_cache:
           key: bundle-cache-{{ checksum "Gemfile.lock" }}
           paths:
-            - vendor/bundle
+            - << parameters.bundle_path >>


### PR DESCRIPTION
Hi @toshimaru 

I added the `bundle_path` option.

We use the official docker image for ruby. In this image, default `BUNDLE_PATH` is `/usr/local/bundle`. That's why I changed this orb to make `BUNDLE_PATH` configurable.

ref. https://github.com/docker-library/ruby/blob/84db469/2.5/stretch/Dockerfile#L65-L66