### PR TITLE
Add cache_key_prefix option

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -34,13 +34,17 @@ commands:
         type: string
         default: vendor/bundle
         description: "Parameter for `bundle install --path`"
+      cache_key_prefix:
+        type: string
+        default: bundle-cache
+        description: "Parameter for CircleCI cache key prefix"
     steps:
       - restore_cache:
           keys: 
-            - bundle-cache-{{ checksum "Gemfile.lock" }}
-            - bundle-cache
+            - << parameters.cache_key_prefix >>-{{ checksum "Gemfile.lock" }}
+            - << parameters.cache_key_prefix >>
       - run: bundle install --jobs=<< parameters.jobs >> --retry=<< parameters.retry >> --path << parameters.bundle_path >>
       - save_cache:
-          key: bundle-cache-{{ checksum "Gemfile.lock" }}
+          key: << parameters.cache_key_prefix >>-{{ checksum "Gemfile.lock" }}
           paths:
             - << parameters.bundle_path >>


### PR DESCRIPTION
Hi @toshimaru 

I added `cache_key_prefix` option to make CircleCI cache key prefix configurable. This is because CircleCI cache is immutable and there is no way to clear the cache. So CircleCI recommends cache versioning by using key prefix.

ref. https://circleci.com/docs/2.0/caching/#clearing-cache

Actually, I faced the problem that I cannot clear the cache. In my case, the problem occured when `Gemfile.lock` is not changed but the build image is changed that the user and HOME directory are different.